### PR TITLE
Fix: Wenn eine Variable keine Werte hatte 

### DIFF
--- a/PDFReportMulti/module.php
+++ b/PDFReportMulti/module.php
@@ -99,8 +99,6 @@ class PDFReportMulti extends IPSModule
             }
 
             $dataValues[$data['VariableID']] = $values;
-            $this->SendDebug('id', $data['VariableID'], 0);
-            $this->SendDebug('Values', print_r($values, true), 0);
         }
 
         return $dataValues;
@@ -172,9 +170,11 @@ EOT;
             $rows .= '<tr>';
             $rows .= '<td width="25%">' . date($this->GetDateTimeFormatForAggreagtion(), $ts) . '</td>';
             foreach ($json as $data) {
+                $rows .= '<td style="text-align: center;">';
                 if (isset($values[$data['VariableID']])) {
-                    $rows .= '<td style="text-align: center;">' . GetValueFormattedEx($data['VariableID'], $values[$data['VariableID']]) . '</td>';
+                    $rows .= GetValueFormattedEx($data['VariableID'], $values[$data['VariableID']]);
                 }
+                $rows .= '</td>';
             }
             $rows .= '</tr>';
         }

--- a/PDFReportMulti/module.php
+++ b/PDFReportMulti/module.php
@@ -99,6 +99,8 @@ class PDFReportMulti extends IPSModule
             }
 
             $dataValues[$data['VariableID']] = $values;
+            $this->SendDebug('id', $data['VariableID'], 0);
+            $this->SendDebug('Values', print_r($values, true), 0);
         }
 
         return $dataValues;
@@ -170,7 +172,9 @@ EOT;
             $rows .= '<tr>';
             $rows .= '<td width="25%">' . date($this->GetDateTimeFormatForAggreagtion(), $ts) . '</td>';
             foreach ($json as $data) {
-                $rows .= '<td style="text-align: center;">' . GetValueFormattedEx($data['VariableID'], $values[$data['VariableID']]) . '</td>';
+                if (isset($values[$data['VariableID']])) {
+                    $rows .= '<td style="text-align: center;">' . GetValueFormattedEx($data['VariableID'], $values[$data['VariableID']]) . '</td>';
+                }
             }
             $rows .= '</tr>';
         }


### PR DESCRIPTION
Wenn eine Variable keine geloggten werte hatte, bzw der momentane Datensatz übersprungen wird, kam es zu Fehlern. 